### PR TITLE
MDL-30562 extra_answer_fields should be public

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -74,7 +74,7 @@ class qtype_pmatchjme extends qtype_pmatch {
     public function save_hints($formdata, $withparts = false) {
         parent::save_hints($formdata, true);
     }
-    protected function extra_answer_fields() {
+    public function extra_answer_fields() {
         return array('qtype_pmatchjme_answers', 'atomcount');
     }
     public function save_extra_answer_data($question, $key, $answerid) {


### PR DESCRIPTION
to allow access from backup and restore classes

This only seems to need to be changing in 2.2+ branch.
