### PR TITLE
Update OU Qtype pmatch for simplified forms #6748

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -15,3 +15,50 @@
 .que.pmatchjme span.answerlabel {
     vertical-align: top;
 }
+/* Editing form. Style repeated elements*/
+/* Top */
+body#page-question-type-pmatchjme div[id^=fitem_id_][id*=answer_],
+body#page-question-type-pmatchjme #fitem_id_addanswers + .fitem {
+    background: #EEE;
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-bottom: 5px;
+    padding-top: 5px;
+    border: 1px solid #BBB;
+    border-bottom: 0;
+}
+
+body#page-question-type-pmatchjme div[id^=fitem_id_][id*=_answer_] .fitemtitle,
+body#page-question-type-pmatchjme #fitem_id_addanswers + .fitem .fitemtitle {
+    font-weight: bold;
+}
+/* Middle */
+body#page-question-type-pmatchjme div[id^=fitem_id_][id*=fraction_],
+body#page-question-type-pmatchjme #fitem_id_addanswers + .fitem + .fitem,
+body#page-question-type-pmatchjme div[id^=fitem_id_][id*=feedback_],
+body#page-question-type-pmatchjme div[id^=fitem_id_][id*=otherfeedback] {
+    background: #EEE;
+    margin-bottom: 0;
+    margin-top: 0;
+    padding-bottom: 5px;
+    padding-top: 5px;
+    border: 1px solid #BBB;
+    border-top: 0;
+    border-bottom: 0;
+}
+/* Bottom */
+body#page-question-type-pmatchjme div[id^=fitem_id_][id*=atomcount_] {
+    background: #EEE;
+    margin-bottom: 2em;
+    margin-top: 0;
+    padding-bottom: 5px;
+    padding-top: 5px;
+    border: 1px solid #BBB;
+    border-top: 0;
+}
+body#page-question-type-pmatchjme #fitem_id_addanswers {
+    margin-bottom: 2em;
+}
+body#page-question-type-pmatchjme #fitem_id_answer_0 {
+    margin-top: 1em;
+}

--- a/version.php
+++ b/version.php
@@ -24,12 +24,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2013021200;
-$plugin->requires  = 2012062500;
+$plugin->version   = 2013050900;
+$plugin->requires  = 2013040500;
 $plugin->cron      = 0;
 $plugin->component = 'qtype_pmatchjme';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.2 for Moodle 2.3+';
+$plugin->release   = '1.3 for Moodle 2.5+';
 
 $plugin->dependencies = array(
     'qtype_pmatch' => 2012062300,


### PR DESCRIPTION
Only had to update style. Just inherited other changes from pmatch. Updated version since it breaks without Moodle 2.5
